### PR TITLE
Add a step of 5 to the dhw.set_point hass mqtt discovery

### DIFF
--- a/exe/aurora_mqtt_bridge
+++ b/exe/aurora_mqtt_bridge
@@ -396,6 +396,7 @@ class MQTTBridge
                       @abc.dhw.set_point,
                       format: 100..140,
                       unit: "°F",
+                      step: 5,
                       hass: :number) do |value, property|
           @mutex.synchronize { property.value = @abc.dhw.set_point = value }
         end


### PR DESCRIPTION
According to the doc of my system the dhw set point needs to be set in increments of 5.

> Use an AID Tool to enable HWG and select the desired water
heating set point. Selectable set points are 100°F – 140°F in
5°F increments (default 130°F). From the Main Menu of the AID
Tool select Setup, then AXB Setup.

I added a [step attribute](https://developers.home-assistant.io/docs/core/entity/number?_highlight=number) of 5 to the appropriate number entity.